### PR TITLE
fix(chore): change/update license to valid string

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - [Development Environment](#development-environment)
   - [Bootstrap the Project](#bootstrap-the-project)
 - [Links](#links)
+- [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -87,3 +88,7 @@ lerna success - @aloxide/example-generate-sm
 
 - [Medium](https://medium.com/@Aloxide)
 - [Google Groups](https://groups.google.com/g/aloxide)
+
+# License
+
+[Apache License 2.0](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "While there are a lot of blockchain softwares available and it's not uncommon to see a requirement to support various blockchains, it still requires a significant amount of time to learn how to write a smart contract just printing \"Hello World\" per blockchain. Aloxide provides a pragmatic abstraction for various blockchain softwares including CAN, EOS, ICON, and so on so that you can focus on business logic on smart contracts without ties to specific blockchain natures. Also based on the abstraction Aloxide offers useful tool-kits for dApp development such as API gateway and SDK.",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/abstraction/package.json
+++ b/packages/abstraction/package.json
@@ -3,7 +3,7 @@
   "description": "Example of using jest with a TS monorepo",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -3,7 +3,7 @@
   "description": "Example of using jest with a TS monorepo",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -3,7 +3,7 @@
   "description": "Example of using jest with a TS monorepo",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/demux/package.json
+++ b/packages/demux/package.json
@@ -3,7 +3,7 @@
   "description": "Example of using jest with a TS monorepo",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/example-api-gateway/package.json
+++ b/packages/example-api-gateway/package.json
@@ -3,7 +3,7 @@
   "description": "Example of using jest with a TS monorepo",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/example-generate-sm/package.json
+++ b/packages/example-generate-sm/package.json
@@ -3,7 +3,7 @@
   "description": "Example of using jest with a TS monorepo",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": "true",
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -3,7 +3,7 @@
   "description": "Example of using jest with a TS monorepo",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -3,7 +3,7 @@
   "description": "Example of using jest with a TS monorepo",
   "version": "0.1.0",
   "author": "Lecle",
-  "license": "Apache-2.0 License",
+  "license": "Apache-2.0",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
There's a warning in packages when running build:
```
warning package.json: License should be a valid SPDX license expression
```

This warning is caused by invalid license string with redundant "License" word we used in package.json (for valid licenses, please check: https://spdx.org/licenses/ and https://docs.npmjs.com/files/package.json#license)